### PR TITLE
31 Fix errors in scheduled task

### DIFF
--- a/cronlib.php
+++ b/cronlib.php
@@ -111,8 +111,8 @@ function flashcard_cron_task() {
                                 'COURSE' => format_string($coursename),
                                 'URL' => $CFG->wwwroot.'/mod/flashcard/view.php?f='.$flashcard->id
                             );
-                            $notification = flashcard_compile_mail_template('notifyreview', $vars, $u->lang);
-                            $notificationhtml = flashcard_compile_mail_template('notifyreview_html', $vars, $u->lang);
+                            $notification = flashcard_compile_mail_template('notify_review', $vars, $u->lang);
+                            $notificationhtml = flashcard_compile_mail_template('notify_review_html', $vars, $u->lang);
                             if ($CFG->debugsmtp) {
                                 mtrace("Sending Review Notification Mail Notification to ".fullname($u).'<br/>'.$notificationhtml);
                             }

--- a/mailtemplatelib.php
+++ b/mailtemplatelib.php
@@ -43,7 +43,7 @@ function flashcard_compile_mail_template($template, $infomap, $lang = '') {
     }
     $lang = substr($lang, 0, 2); // Be sure we are in moodle 2.
 
-    $notification = implode('', flashcard_get_mail_template($template, $lang));
+    $notification = flashcard_get_mail_template($template, $lang);
     foreach ($infomap as $akey => $avalue) {
         $notification = str_replace("<%%$akey%%>", $avalue, $notification);
     }
@@ -58,6 +58,6 @@ function flashcard_compile_mail_template($template, $infomap, $lang = '') {
  */
 function flashcard_get_mail_template($virtual, $lang = '') {
 
-    return new lang_string($virtual.'_tpl', 'flashcard', '', $lang);
+    return new lang_string($virtual.'_tpl', 'mod_flashcard', '', $lang);
 
 }


### PR DESCRIPTION
Fix the following errors when mod_flashcard\task\cron_task runs:

  ++ String does not exist. Please check your string definition for
  notifyreview_tpl/flashcard ++

and

  implode(): Argument #2 ($array) must be of type ?array, lang_string
  given